### PR TITLE
グラフの色を感染者数によって段階的に色分けする

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -5,6 +5,11 @@ const LAST_DATE = "2020-02-27T00:00:00+09:00";
 const AGE_LABELS = ["80代","70代","60代","50代","40代","30代","20代","10代","10歳未満"];
 const COLORS = {
   default: "#3dc",
+  high: "#f80",
+  middle: "#fb3",
+  low: "#fe9",
+  gray: "#666",
+  others: "rgba(255,255,255,0.4)",
   gender: {
     f: "#FE9",
     m: "#2B9"
@@ -124,6 +129,24 @@ const init = () => {
     window.myChart = new Chart(ctx, config);
   }
 
+  const getPrefColor = (prefName) => {
+    let pref = gRegions.find(region => region.label === prefName);
+    if (pref === undefined) {
+      return COLORS.gray;
+    }
+
+    let prefNumber = pref.value;
+    if (prefNumber >= 45) {
+      return COLORS.high;
+    } else if (prefNumber >= 30) {
+      return COLORS.middle;
+    } else if  (prefNumber >= 15) {
+      return COLORS.low;
+    } else if (prefNumber > 0) {
+      return COLORS.default;
+    }
+  }
+
   const drawRegionChart = () => {
     const convertRegionName = (name) => {
       if (name === "東京") {name = "東京都";}
@@ -171,11 +194,10 @@ const init = () => {
     gRegions.forEach(function(region, i){
       cLabels.push(region.label);
       cValues.push(region.value);
-
       if (region.label === "中国居住者" || region.label === "調査中") {
-        cColors.push("rgba(255,255,255,0.4)");
+        cColors.push(COLORS.others);
       } else {
-        cColors.push(COLORS.default);
+        cColors.push(getPrefColor(region.label));
       }
     });
 
@@ -245,14 +267,6 @@ const init = () => {
   }
 
   const drawJapanMap = () => {
-    const getPrefColor = (name) => {
-      let ret = "#666";
-      gRegions.forEach(function(region, i){
-        if (region.label === name) ret = COLORS.default;
-      });
-      return ret;
-    }
-
     let width = $("#japan-map").width();
     let prefs = [
       {code:1,jp:"北海道",en:"Hokkaido",color:getPrefColor("北海道"),hoverColor:getPrefColor("北海道"),prefectures:[1]},

--- a/js/script.js
+++ b/js/script.js
@@ -15,6 +15,11 @@ const COLORS = {
     m: "#2B9"
   }
 };
+const THRESHOLDS = {
+  high: 45,
+  middle: 30,
+  low: 15,
+};
 
 
 const init = () => {
@@ -130,17 +135,17 @@ const init = () => {
   }
 
   const getPrefColor = (prefName) => {
-    let pref = gRegions.find(region => region.label === prefName);
+    const pref = gRegions.find(region => region.label === prefName);
     if (pref === undefined) {
       return COLORS.gray;
     }
 
-    let prefNumber = pref.value;
-    if (prefNumber >= 45) {
+    const prefNumber = pref.value;
+    if (prefNumber >= THRESHOLDS.high) {
       return COLORS.high;
-    } else if (prefNumber >= 30) {
+    } else if (prefNumber >= THRESHOLDS.middle) {
       return COLORS.middle;
-    } else if  (prefNumber >= 15) {
+    } else if  (prefNumber >= THRESHOLDS.low) {
       return COLORS.low;
     } else if (prefNumber > 0) {
       return COLORS.default;


### PR DESCRIPTION
はじめまして。友だちからページを教えてもらってこのページを知りました。ビジュアライスするとひと目で状況がわかり、とても素晴らしいと思います！

現在は、地図の感染者数に関わらず、同じ色で都道府県が表示されています。ですが、感染者の人数によって色を変化させれば、さらに状況が理解しやすくなるのではないかと思い、段階的な色付けを実装してみました。いかがでしょうか？ 意見をいただけると嬉しいです。

## 色を付けた部分

このように感染者数によって色が変わります。

### Before

<img width="678" alt="Screen Shot 2020-02-28 at 22 21 00" src="https://user-images.githubusercontent.com/1425259/75553083-09cb0a00-5a7b-11ea-82f6-240c6e5028dd.png">

### After

<img width="667" alt="Screen Shot 2020-02-28 at 22 21 15" src="https://user-images.githubusercontent.com/1425259/75553105-15b6cc00-5a7b-11ea-937e-d08c66d7bcad.png">

## 検討事項

### 配色について

<img width="324" alt="Screen Shot 2020-02-28 at 22 12 31" src="https://user-images.githubusercontent.com/1425259/75553318-84942500-5a7b-11ea-8d80-1a780b6170e5.png">

現在は、仮に感染者15人、30人、45人をしきい値にして、上のような薄い黄色、濃い黄色、オレンジという配色にしています。もし他の色のほうが良ければ教えてください。また、このしきい値は今後の人数の変化によっては変える必要があると思います。

### minify について

まだ `script.js` の minify を行っていません。手元で動作を確認するには、お手数ですが以下のように `index.html` の `script.min.js` の部分を `script.js` に置き換えてください。

```diff
diff --git a/index.html b/index.html
index 1158f57..b8a5b0a 100644
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="js/jquery.japan-map.min.js"></script>
-    <script src="js/script.min.js"></script>
+    <script src="js/script.js"></script>
   </body>
 </html>
```