### PR TITLE
ホバー時のエラーを修正

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -449,7 +449,7 @@ const init = () => {
     $.getJSON("data/data.json", function(data){
       gData = data;
       drawTransitionChart();
-      drawRegionChart("", true);
+      drawRegionChart("", false);
       drawJapanMap();
       drawDemographicChart();
       $("#container").addClass("show");


### PR DESCRIPTION
# ホバー時のエラーを修正
- エラー内容
右下のグラフをホバーすると`Uncaught TypeError: i is not a function`が出てしまい、それ以降全てのホバー時の詳細情報が出てこなくなる。
- 原因
`drawRegionChart("", true);`関数内の引数に`true`が渡されているため。
- 変更
`drawRegionChart("", true);` → `drawRegionChart("", false);`に変更しました。
> ホバー前
![before_hover](https://user-images.githubusercontent.com/53123867/75610550-85998500-5b55-11ea-90e6-c80a353851f0.jpeg)

> ホバー後(マウスの位置はホバー前と一緒)
![after_hover](https://user-images.githubusercontent.com/53123867/75610525-4c611500-5b55-11ea-948c-098d24200adb.jpeg)