### PR TITLE
Solve animation error

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -197,7 +197,9 @@ const init = () => {
       },
       options: {
         aspectRatio: 0.8,
-        animation: isAnimated,
+        animation: {
+          duration: isAnimated
+          },
         responsive: true,
         legend: {
           display: false
@@ -338,7 +340,7 @@ const init = () => {
       movesIslands : true,
       fontSize : 11,
       onSelect : function(data){
-        drawRegionChart(data.name, false);
+        drawRegionChart(data.name, 0);
       }
     });
   }
@@ -449,7 +451,7 @@ const init = () => {
     $.getJSON("data/data.json", function(data){
       gData = data;
       drawTransitionChart();
-      drawRegionChart("", false);
+      drawRegionChart("", 1000);
       drawJapanMap();
       drawDemographicChart();
       $("#container").addClass("show");

--- a/js/script.js
+++ b/js/script.js
@@ -449,7 +449,7 @@ const init = () => {
     $.getJSON("data/data.json", function(data){
       gData = data;
       drawTransitionChart();
-      drawRegionChart("", true);
+      drawRegionChart("", false);
       drawJapanMap();
       drawDemographicChart();
       $("#container").addClass("show");


### PR DESCRIPTION
# アニメーションの制御方法を変更しました
- なぜ
現状だとUIが崩れてしまう場合があるため

- 原因
chartjsのアニメーション設定に不具合があり、animationをtrue/falseで制御するとエラーが発生してしまうため 
> animationの値をfalse→trueに変更する場合はよいが、初期値がtrueだとエラーが発生

- 解決策
現状、`drawRegionChart`の第二引数が`isAnimated`、チャートのアニメーション設定が`animation: isAnimated,`となっていて、`isAnimated`の値が`true`か`false`かでアニメーション有無を決めています。
ロード時は`true`、都道府県を選択した際は`false`が渡されていますが、`animation: true,`にするとエラーが出てしまいます。
ということで、アニメーション制御をアニメーションオプションの1つである`duration`で行います。
まず、アニメーション設定部分を`animation: {duration: isAnimated},`、これにより、isAnimationの値を数値の0か1000にすることでアニメーション有無が決定されます。
次に今まで`true/false`だったところを`1000/0`に変更します。
これにより、エラーを出さずにアニメーションの制御が行えます。

> durationのデフォルトは1000, 0の場合はアニメーションにかかる時間が0=アニメーション無し


# エラーによるUIの変化
- 正常なUI
![before_hover](https://user-images.githubusercontent.com/53123867/75612861-f0a18680-5b6a-11ea-96a6-2b4fe1f7588f.jpeg)

- エラー後のUI　
*都道府県の選択をする前に右下のグラフをホバーすると、他のグラフをホバーしても詳細情報が出てきません
![after_hover](https://user-images.githubusercontent.com/53123867/75612863-f39c7700-5b6a-11ea-9b43-c5646ee92d0a.jpeg)


# エラーコード
![スクリーンショット 2020-03-01 3 22 02](https://user-images.githubusercontent.com/53123867/75612993-1aa77880-5b6c-11ea-8e6a-9a943472e244.jpeg)