### PR TITLE
「新規」グラフのツールチップが「累計」のものになっている問題を修正

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -68,9 +68,23 @@ const init = () => {
             },
             label: function(tooltipItem, data){
               let row = gData.transition[tooltipItem.index];
-              let ret = ["患者数：" + (row[5]) + "名"];
-                  ret.push("　うち退院：" + row[6] + "名");
-                  ret.push("　同　死亡：" + row[7] + "名");
+              let ret;
+              if ($("#patients-block").find(".switch.selected").attr("value") === "new") {
+                const prev = gData.transition[tooltipItem.index - 1];
+                if (tooltipItem.index === 0) {
+                  ret = ["患者数：" + (row[5]) + "名"];
+                  ret.push("退院：" + (row[6]) + "名");
+                  ret.push("死亡：" + (row[7]) + "名");
+                } else {
+                  ret = ["患者数：" + (row[5] - prev[5]) + "名"];
+                  ret.push("退院：" + (row[6] - prev[6]) + "名");
+                  ret.push("死亡：" + (row[7] - prev[7]) + "名");
+                }
+              } else {
+                ret = ["患者数：" + (row[5]) + "名"];
+                ret.push("　うち退院：" + row[6] + "名");
+                ret.push("　同　死亡：" + row[7] + "名");
+              }
               return ret;
             }
           }
@@ -175,9 +189,17 @@ const init = () => {
             },
             label: function(tooltipItem, data){
               let row = gData.transition[tooltipItem.index];
-              let ret = ["PCR検査数：" + (row[3]) + "名"];
+              let ret;
+                if ($("#surveys-block").find(".switch.selected").attr("value") === "new" && tooltipItem.index >= 1) {
+                  const prev = gData.transition[tooltipItem.index - 1];
+                  ret = ["PCR検査数：" + (row[3] - prev[3]) + "名"];
+                  ret.push("　うち陽性：" + (row[4] - prev[4]) + "名");
+                  ret.push("　同　有症：" + (row[5] - prev[5]) + "名");
+                } else {
+                  ret = ["PCR検査数：" + (row[3]) + "名"];
                   ret.push("　うち陽性：" + row[4] + "名");
                   ret.push("　同　有症：" + row[5] + "名");
+                }
               return ret;
             }
           }


### PR DESCRIPTION
#15 の修正です。
labelを累計・新規の選択によって切り替える部分が実装されていなかったため、既に実装されているグラフ描画部分のコードを参考に実装しました。

## 修正前
![image](https://user-images.githubusercontent.com/42484226/75674913-6cb1e080-5cc9-11ea-9db8-73c440684868.png)

## 修正後
![image](https://user-images.githubusercontent.com/42484226/75674991-966b0780-5cc9-11ea-99b9-c82c576c1f5e.png)
