### PR TITLE
新型コロナウイルス感染症対策サイトのリンクを追加

### DIFF
--- a/en.html
+++ b/en.html
@@ -119,6 +119,17 @@
             <div class="link">
               <a href="https://toyokeizai.net/category/corona-large-ripples" target="_blank"><img src="img/image-series-02.jpg" /></a>
             </div>
+		  <h3>関連リンク</h3>
+          <h4>Click to jump to COVID-19 Task Force website</h4>
+          <div class="links">
+          <a href="https://stopcovid19.metro.tokyo.lg.jp" target="_blank">Tokyo COVID-19 Task Force website </a><br>
+          <a href="https://stopcovid19.hokkaido.dev/" target="_blank">Hokkaido COVID-19 Task Force website </a><br>
+          <a href="https://www.pref.kanagawa.jp/osirase/1369/" target="_blank">Kanagawa COVID-19 Task Force website </a><br>
+          <a href="https://stopcovid19.code4.nagoya/" target="_blank">Aichi COVID-19 Task Force website </a>
+          </div>
+        </div>
+		  
+		  
           </div>
         </div>
         <p><small lang="en">© 2020 Toyo Keizai Inc.</small></p>

--- a/en.html
+++ b/en.html
@@ -119,7 +119,7 @@
             <div class="link">
               <a href="https://toyokeizai.net/category/corona-large-ripples" target="_blank"><img src="img/image-series-02.jpg" /></a>
             </div>
-		  <h3>関連リンク</h3>
+		  <h3>Link</h3>
           <h4>Click to jump to COVID-19 Task Force website</h4>
           <div class="links">
           <a href="https://stopcovid19.metro.tokyo.lg.jp" target="_blank">Tokyo COVID-19 Task Force website </a><br>

--- a/index.html
+++ b/index.html
@@ -114,11 +114,19 @@
           <h4>画像をクリックすると特集記事一覧にジャンプします</h4>
           <div class="links">
             <div class="link">
-              <a href="https://toyokeizai.net/category/corona-virus" target="_blank"><img src="img/image-series-01.jpg" /></a>
+              <a href="https://toyokeizai.net/category/corona-virus" target="_blank"><img src="https://toyokeizai.net/sp/visual/tko/covid19/img/image-series-01.jpg" /></a>
             </div>
             <div class="link">
-              <a href="https://toyokeizai.net/category/corona-large-ripples" target="_blank"><img src="img/image-series-02.jpg" /></a>
+              <a href="https://toyokeizai.net/category/corona-large-ripples" target="_blank"><img src="https://toyokeizai.net/sp/visual/tko/covid19/img/image-series-02.jpg" /></a>
             </div>
+          </div>
+          <h3>関連リンク</h3>
+          <h4>リンクをクリックすると新型コロナウイルス感染症対策サイトにジャンプします</h4>
+          <div class="links">
+          <a href="https://stopcovid19.metro.tokyo.lg.jp" target="_blank">東京都 新型コロナウイルス感染症対策サイト </a><br>
+          <a href="https://stopcovid19.hokkaido.dev/" target="_blank">北海道 新型コロナウイルス感染症対策サイト</a><br>
+          <a href="https://www.pref.kanagawa.jp/osirase/1369/" target="_blank">神奈川県 新型コロナウイルス感染症対策サイト</a><br>
+          <a href="https://stopcovid19.code4.nagoya/" target="_blank">愛知県 新型コロナウイルス感染症対策サイト</a>
           </div>
         </div>
         <p><small lang="en">© 2020 Toyo Keizai Inc.</small></p>
@@ -130,3 +138,4 @@
     <script src="js/script.min.js"></script>
   </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
               <a href="https://toyokeizai.net/category/corona-large-ripples" target="_blank"><img src="https://toyokeizai.net/sp/visual/tko/covid19/img/image-series-02.jpg" /></a>
             </div>
           </div>
+		
           <h3>関連リンク</h3>
           <h4>リンクをクリックすると新型コロナウイルス感染症対策サイトにジャンプします</h4>
           <div class="links">


### PR DESCRIPTION
東京都とその他の他県が開設している新型コロナウイルス感染症対策サイトのリンクを追加。